### PR TITLE
feat: allowing studio asides for course-authoring MFE

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -201,7 +201,7 @@ const mapStateToProps = (state) => ({
   asidesURL: `${selectors.app.studioEndpointUrl(state)
   }/asides/${
     selectors.app.blockId(state)}`,
-  asidesEnabled: selectors.problem.defaultSettings(state).advancedModules?.length > 0,
+  asidesEnabled: selectors.problem.hasAsides(state),
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -36,6 +36,8 @@ export const SettingsWidget = ({
   updateField,
   updateAnswer,
   defaultSettings,
+  asidesURL,
+  asidesEnabled,
 }) => {
   const { isAdvancedCardsVisible, showAdvancedCards } = showAdvancedSettingsCards();
 
@@ -88,6 +90,17 @@ export const SettingsWidget = ({
         <HintsCard problemType={problemType} hints={settings.hints} updateSettings={updateSettings} />
       </div>
       {feedbackCard()}
+      {asidesEnabled && (
+      <div>
+        <iframe
+          title="asides-iframe"
+          src={asidesURL}
+          allowFullScreen
+          frameBorder="0"
+          width={500}
+        />
+      </div>
+      )}
       <div>
         <Collapsible.Advanced open={!isAdvancedCardsVisible}>
           <Collapsible.Body className="collapsible-body small">
@@ -174,6 +187,8 @@ SettingsWidget.propTypes = {
   }).isRequired,
   // eslint-disable-next-line
   settings: PropTypes.any.isRequired,
+  asidesURL: PropTypes.string.isRequired,
+  asidesEnabled: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = (state) => ({
@@ -183,6 +198,10 @@ const mapStateToProps = (state) => ({
   blockTitle: selectors.app.blockTitle(state),
   correctAnswerCount: selectors.problem.correctAnswerCount(state),
   defaultSettings: selectors.problem.defaultSettings(state),
+  asidesURL: `${selectors.app.studioEndpointUrl(state)
+  }/asides/${
+    selectors.app.blockId(state)}`,
+  asidesEnabled: selectors.problem.defaultSettings(state).advancedModules?.length > 0,
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/data/redux/problem/selectors.js
+++ b/src/editors/data/redux/problem/selectors.js
@@ -12,6 +12,7 @@ export const simpleSelectors = {
   settings: mkSimpleSelector(problemData => problemData.settings),
   question: mkSimpleSelector(problemData => problemData.question),
   defaultSettings: mkSimpleSelector(problemData => problemData.defaultSettings),
+  hasAsides: mkSimpleSelector(problemData => problemData.hasAsides),
   completeState: mkSimpleSelector(problemData => problemData),
 };
 

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -56,7 +56,7 @@ export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispat
 };
 
 export const fetchAdvancedSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
-  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', 'rerandomize'];
+  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', 'rerandomize', 'advanced_modules'];
   dispatch(requests.fetchAdvancedSettings({
     onSuccess: (response) => {
       const defaultSettings = {};

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -47,16 +47,23 @@ export const getDataFromOlx = ({ rawOLX, rawSettings, defaultSettings }) => {
   return { settings: parsedSettings };
 };
 
-export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispatch) => {
+export const loadProblem = ({
+  rawOLX, rawSettings, hasAsides, defaultSettings,
+}) => (dispatch) => {
   if (isBlankProblem({ rawOLX })) {
     dispatch(actions.problem.setEnableTypeSelection(camelizeKeys(defaultSettings)));
   } else {
-    dispatch(actions.problem.load(getDataFromOlx({ rawOLX, rawSettings, defaultSettings })));
+    dispatch(actions.problem.load({
+      ...getDataFromOlx({
+        rawOLX, rawSettings, hasAsides, defaultSettings,
+      }),
+      hasAsides,
+    }));
   }
 };
 
-export const fetchAdvancedSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
-  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', 'rerandomize', 'advanced_modules'];
+export const fetchAdvancedSettings = ({ rawOLX, rawSettings, hasAsides }) => (dispatch) => {
+  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', 'rerandomize'];
   dispatch(requests.fetchAdvancedSettings({
     onSuccess: (response) => {
       const defaultSettings = {};
@@ -66,16 +73,23 @@ export const fetchAdvancedSettings = ({ rawOLX, rawSettings }) => (dispatch) => 
         }
       });
       dispatch(actions.problem.updateField({ defaultSettings: camelizeKeys(defaultSettings) }));
-      loadProblem({ rawOLX, rawSettings, defaultSettings })(dispatch);
+      loadProblem({
+        rawOLX, rawSettings, hasAsides, defaultSettings,
+      })(dispatch);
     },
-    onFailure: () => { loadProblem({ rawOLX, rawSettings, defaultSettings: {} })(dispatch); },
+    onFailure: () => {
+      loadProblem({
+        rawOLX, rawSettings, hasAsides, defaultSettings: {},
+      })(dispatch);
+    },
   }));
 };
 
 export const initializeProblem = (blockValue) => (dispatch) => {
   const rawOLX = _.get(blockValue, 'data.data', {});
   const rawSettings = _.get(blockValue, 'data.metadata', {});
-  dispatch(fetchAdvancedSettings({ rawOLX, rawSettings }));
+  const hasAsides = _.get(blockValue, 'data.has_cms_asides', false);
+  dispatch(fetchAdvancedSettings({ rawOLX, rawSettings, hasAsides }));
 };
 
 export default { initializeProblem, switchToAdvancedEditor, fetchAdvancedSettings };


### PR DESCRIPTION
## Supporting Information
Issue: https://github.com/openedx/frontend-app-course-authoring/issues/545
PR: https://github.com/Anas12091101/edx-platform/pull/2

## Description
This PR is for enabling the aside's studio view in course-authoring MFE using iframe.

## Screenshot
<img width="941" alt="Screenshot 2024-01-05 at 3 59 47 PM" src="https://github.com/Anas12091101/frontend-lib-content-components/assets/88967643/6493a0d7-00f3-4cd1-a9d3-36bd94ae2d32">
